### PR TITLE
build: Use configured repo when publishing to daemon

### DIFF
--- a/pkg/commands/options/publish.go
+++ b/pkg/commands/options/publish.go
@@ -33,9 +33,6 @@ type PublishOptions struct {
 	// In normal ko usage, this is populated with the value of $KO_DOCKER_REPO.
 	DockerRepo string
 
-	// LocalDomain overrides the default domain for images loaded into the local Docker daemon. Use with Local=true.
-	LocalDomain string
-
 	// UserAgent enables overriding the default value of the `User-Agent` HTTP
 	// request header used when pushing the built image to an image registry.
 	UserAgent string

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -177,7 +177,7 @@ func makePublisher(po *options.PublishOptions) (publish.Interface, error) {
 			// not be true.
 			return publish.NewDaemon(namer, po.Tags,
 				publish.WithDockerClient(po.DockerClient),
-				publish.WithLocalDomain(po.LocalDomain),
+				publish.WithLocalDomain(repoName),
 			)
 		}
 		if repoName == publish.KindDomain {

--- a/pkg/commands/resolver_test.go
+++ b/pkg/commands/resolver_test.go
@@ -259,16 +259,6 @@ func TestNewPublisherCanPublish(t *testing.T) {
 			},
 		},
 		{
-			description:   "override LocalDomain",
-			wantImageName: fmt.Sprintf("%s/%s", localDomain, importpath),
-			po: &options.PublishOptions{
-				Local:               true,
-				LocalDomain:         localDomain,
-				PreserveImportPaths: true,
-				DockerClient:        &kotesting.MockDaemon{},
-			},
-		},
-		{
 			description:   "override DockerClient",
 			wantImageName: strings.ToLower(fmt.Sprintf("%s/%s", localDomain, importpath)),
 			po: &options.PublishOptions{


### PR DESCRIPTION
Use configured image repository when publishing to Docker daemon, instead of hardcoding to ko.local.